### PR TITLE
Client request creation and sending

### DIFF
--- a/chat_completion.go
+++ b/chat_completion.go
@@ -78,5 +78,6 @@ func (mc *MistralClient) CreateChatCompletion(ctx context.Context, body ChatComp
 }
 
 func (mc *MistralClient) CreateChatCompletionStream(ctx context.Context, body ChatCompletionRequest) (resp ChatCompletionStreamResponse, err error) {
+	// TODO: implement streaming request and response handling
 	return resp, nil
 }

--- a/chat_completion.go
+++ b/chat_completion.go
@@ -1,6 +1,9 @@
 package mistral
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
 
 type FinishReason int
 
@@ -64,10 +67,16 @@ type ChatCompletionResponse struct {
 	Usage   UsageInfo                      `json:"usage"`
 }
 
-func (mc *MistralClient) CreateChatCompletion(ctx context.Context, req ChatCompletionRequest) (resp ChatCompletionResponse, err error) {
-	return resp, nil
+func (mc *MistralClient) CreateChatCompletion(ctx context.Context, body ChatCompletionRequest) (resp ChatCompletionResponse, err error) {
+	req, err := mc.newRequest(ctx, http.MethodPost, mc.endpoint("/chat/completions"), body)
+	if err != nil {
+		return
+	}
+
+	err = mc.sendRequest(req, &resp)
+	return
 }
 
-func (mc *MistralClient) CreateChatCompletionStream(ctx context.Context, req ChatCompletionRequest) (resp ChatCompletionStreamResponse, err error) {
+func (mc *MistralClient) CreateChatCompletionStream(ctx context.Context, body ChatCompletionRequest) (resp ChatCompletionStreamResponse, err error) {
 	return resp, nil
 }

--- a/client.go
+++ b/client.go
@@ -1,5 +1,13 @@
 package mistral
 
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
 // MistralClient is the Mistral API client
 type MistralClient struct {
 	config ClientConfig
@@ -9,4 +17,75 @@ type MistralClient struct {
 func NewMistralClient(apiKey string) *MistralClient {
 	config := DefaultConfig(apiKey)
 	return &MistralClient{config: config}
+}
+
+func isRetryStatusCode(resp *http.Response) bool {
+	return resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusInternalServerError || resp.StatusCode == http.StatusBadGateway || resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusGatewayTimeout
+}
+
+func isFailureStatusCode(resp *http.Response) bool {
+	return resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest
+}
+
+func (mc *MistralClient) endpoint(path string) string {
+	return mc.config.BaseURL + path
+}
+
+func (mc *MistralClient) newRequest(ctx context.Context, method, url string, body any) (*http.Request, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		if reader, ok := body.(io.Reader); ok {
+			body = reader
+		} else {
+			bodyBytes, err := json.Marshal(body)
+			if err != nil {
+				return nil, err
+			}
+			body = bytes.NewReader(bodyBytes)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json; charset=utf-8")
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+mc.config.ApiKey)
+
+	return req, nil
+}
+
+func (mc *MistralClient) sendRequest(req *http.Request, respBody interface{}) error {
+	resp, err := mc.config.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if isRetryStatusCode(resp) {
+		return mc.handleRetryResp(resp)
+	}
+
+	if isFailureStatusCode(resp) {
+		return mc.handleErrorResp(resp)
+	}
+
+	if respBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (mc *MistralClient) handleRetryResp(resp *http.Response) error {
+	return nil
+}
+
+func (mc *MistralClient) handleErrorResp(resp *http.Response) error {
+	return nil
 }

--- a/client.go
+++ b/client.go
@@ -28,7 +28,7 @@ func isFailureStatusCode(resp *http.Response) bool {
 }
 
 func (mc *MistralClient) endpoint(path string) string {
-	return mc.config.BaseURL + path
+	return mc.config.BaseURL + "/" + mc.config.Version + path
 }
 
 func (mc *MistralClient) newRequest(ctx context.Context, method, url string, body any) (*http.Request, error) {

--- a/config.go
+++ b/config.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	// DefaultMistralURLv1 is the default URL for the Mistral v1 API
-	DefaultMistralURLv1 = "https://api.mistral.ai/v1"
+	// DefaultMistralURL is the default URL for the Mistral API
+	DefaultMistralURL = "https://api.mistral.ai"
 )
 
 type ClientConfig struct {
@@ -16,6 +16,9 @@ type ClientConfig struct {
 
 	// BaseURL is the base URL for the Mistral API
 	BaseURL string
+
+	// Version is the version of the Mistral API
+	Version string
 
 	// HTTPClient is the HTTP client used for requests
 	HTTPClient *http.Client
@@ -30,7 +33,8 @@ type ClientConfig struct {
 func DefaultConfig(apiKey string) ClientConfig {
 	return ClientConfig{
 		ApiKey:     apiKey,
-		BaseURL:    DefaultMistralURLv1,
+		BaseURL:    DefaultMistralURL,
+		Version:    "v1",
 		HTTPClient: http.DefaultClient,
 		MaxRetries: 5,
 		Timeout:    120 * time.Second,

--- a/embeddings.go
+++ b/embeddings.go
@@ -1,6 +1,9 @@
 package mistral
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
 
 type EmbeddingObject struct {
 	Object    string    `json:"object"`
@@ -21,6 +24,12 @@ type EmbeddingResponse struct {
 	Usage  UsageInfo         `json:"usage"`
 }
 
-func (mc *MistralClient) CreateEmbedding(ctx context.Context, req *EmbeddingRequest) (resp *EmbeddingResponse, err error) {
-	return resp, err
+func (mc *MistralClient) CreateEmbedding(ctx context.Context, body *EmbeddingRequest) (resp *EmbeddingResponse, err error) {
+	req, err := mc.newRequest(ctx, http.MethodPost, mc.endpoint("/embeddings"), body)
+	if err != nil {
+		return
+	}
+
+	err = mc.sendRequest(req, &resp)
+	return
 }

--- a/models.go
+++ b/models.go
@@ -1,5 +1,10 @@
 package mistral
 
+import (
+	"context"
+	"net/http"
+)
+
 type ModelPermission struct {
 	ID                 string  `json:"id"`
 	Object             string  `json:"object"`
@@ -30,6 +35,12 @@ type ModelList struct {
 	Data   []ModelCard `json:"data"`
 }
 
-func (mc *MistralClient) ListModels() (resp *ModelList, err error) {
-	return resp, err
+func (mc *MistralClient) ListModels(ctx context.Context) (resp *ModelList, err error) {
+	req, err := mc.newRequest(ctx, http.MethodGet, mc.endpoint("/models"), nil)
+	if err != nil {
+		return
+	}
+
+	err = mc.sendRequest(req, &resp)
+	return
 }


### PR DESCRIPTION
 - `newRequest` and `sendRequest` methods on `MistralClient` to prepare and send requests
 - Implemented the request sending for all non-streaming endpoints