### PR TITLE
Request error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# Env file
+.env

--- a/chat_completion.go
+++ b/chat_completion.go
@@ -5,17 +5,6 @@ import (
 	"net/http"
 )
 
-type FinishReason int
-
-const (
-	Stop FinishReason = iota
-	Length
-)
-
-func (r FinishReason) String() string {
-	return [...]string{"stop", "length"}[r]
-}
-
 type ChatMessage struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
@@ -29,33 +18,33 @@ type DeltaMessage struct {
 type ChatCompletionRequest struct {
 	Model       string        `json:"model"`
 	Messages    []ChatMessage `json:"messages"`
-	Temperature *float64      `json:"temperature"`
-	MaxTokens   *int          `json:"max_tokens"`
-	TopP        *float64      `json:"top_p"`
-	RandomSeed  *int          `json:"random_seed"`
-	Stream      *bool         `json:"stream"`
-	SafeMode    *bool         `json:"safe_mode"`
+	Temperature *float64      `json:"temperature,omitempty"`
+	MaxTokens   *int          `json:"max_tokens,omitempty"`
+	TopP        *float64      `json:"top_p,omitempty"`
+	RandomSeed  *int          `json:"random_seed,omitempty"`
+	Stream      *bool         `json:"stream,omitempty"`
+	SafeMode    *bool         `json:"safe_mode,omitempty"`
 }
 
 type ChatCompletionResponseStreamChoice struct {
-	Index        int           `json:"index"`
-	Delta        DeltaMessage  `json:"delta"`
-	FinishReason *FinishReason `json:"finish_reason"`
+	Index        int          `json:"index"`
+	Delta        DeltaMessage `json:"delta"`
+	FinishReason *string      `json:"finish_reason,omitempty"`
 }
 
 type ChatCompletionStreamResponse struct {
 	ID      string                               `json:"id"`
 	Model   string                               `json:"model"`
 	Choices []ChatCompletionResponseStreamChoice `json:"choices"`
-	Created *int64                               `json:"created"`
-	Object  *string                              `json:"object"`
-	Usage   *UsageInfo                           `json:"usage"`
+	Created *int64                               `json:"created,omitempty"`
+	Object  *string                              `json:"object,omitempty"`
+	Usage   *UsageInfo                           `json:"usage,omitempty"`
 }
 
 type ChatCompletionResponseChoice struct {
-	Index        int           `json:"index"`
-	Message      ChatMessage   `json:"message"`
-	FinishReason *FinishReason `json:"finish_reason"`
+	Index        int         `json:"index"`
+	Message      ChatMessage `json:"message"`
+	FinishReason *string     `json:"finish_reason,omitempty"`
 }
 
 type ChatCompletionResponse struct {

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -98,5 +99,15 @@ func (mc *MistralClient) sendRequest(req *http.Request, respBody interface{}) er
 }
 
 func (mc *MistralClient) handleErrorResp(resp *http.Response) error {
-	return nil
+	var (
+		errResp    ErrorResponse
+		errMessage ErrorMessage
+	)
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		return err
+	}
+	if err := json.Unmarshal([]byte(errResp.Message), &errMessage); err != nil {
+		return err
+	}
+	return fmt.Errorf("error code %s: %s", errResp.Code, errMessage.Detail[0].Msg)
 }

--- a/common.go
+++ b/common.go
@@ -3,5 +3,5 @@ package mistral
 type UsageInfo struct {
 	PromptTokens     int  `json:"prompt_tokens"`
 	TotalTokens      int  `json:"total_tokens"`
-	CompletionTokens *int `json:"completion_tokens"`
+	CompletionTokens *int `json:"completion_tokens,omitempty"`
 }

--- a/config.go
+++ b/config.go
@@ -25,18 +25,16 @@ type ClientConfig struct {
 
 	// MaxRetries is the maximum number of retries for a request
 	MaxRetries int
-
-	// Timeout is the timeout for a request
-	Timeout time.Duration
 }
 
 func DefaultConfig(apiKey string) ClientConfig {
 	return ClientConfig{
-		ApiKey:     apiKey,
-		BaseURL:    DefaultMistralURL,
-		Version:    "v1",
-		HTTPClient: http.DefaultClient,
+		ApiKey:  apiKey,
+		BaseURL: DefaultMistralURL,
+		Version: "v1",
+		HTTPClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
 		MaxRetries: 5,
-		Timeout:    120 * time.Second,
 	}
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,24 @@
+package mistral
+
+type ErrorContext struct {
+	EnumValues []string `json:"enum_values"`
+}
+
+type ErrorDetail []struct {
+	Loc     []any        `json:"loc"`
+	Msg     string       `json:"msg"`
+	Type    string       `json:"type"`
+	Context ErrorContext `json:"ctx"`
+}
+
+type ErrorMessage struct {
+	Detail ErrorDetail `json:"detail"`
+}
+
+type ErrorResponse struct {
+	Code    string  `json:"code"`
+	Message string  `json:"message"`
+	Object  string  `json:"object"`
+	Param   *string `json:"param,omitempty"`
+	Type    string  `json:"type"`
+}

--- a/examples/chat-no-streaming/main.go
+++ b/examples/chat-no-streaming/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/robertjkeck2/go-mistral"
+)
+
+func main() {
+	client := mistral.NewMistralClient(os.Getenv("MISTRAL_API_KEY"))
+	resp, err := client.CreateChatCompletion(
+		context.Background(),
+		mistral.ChatCompletionRequest{
+			Model:    "mistral-tiny",
+			Messages: []mistral.ChatMessage{{Role: "user", Content: "What is the best French cheese?"}},
+		},
+	)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(resp.Choices[0].Message.Content)
+}

--- a/examples/chat-with-streaming/main.go
+++ b/examples/chat-with-streaming/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	// TODO
+}

--- a/examples/embeddings/main.go
+++ b/examples/embeddings/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	// TODO
+}

--- a/examples/models/main.go
+++ b/examples/models/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	// TODO
+}

--- a/models.go
+++ b/models.go
@@ -16,7 +16,7 @@ type ModelPermission struct {
 	AllowView          bool    `json:"allow_view"`
 	AllowFineTuning    bool    `json:"allow_fine_tuning"`
 	Organization       string  `json:"organization"`
-	Group              *string `json:"group"`
+	Group              *string `json:"group,omitempty"`
 	IsBlocking         bool    `json:"is_blocking"`
 }
 


### PR DESCRIPTION
 - Implements exponential backoff retries in `sendRequest` logic
 - Initializes the HTTP client with a default timeout (TODO: make this configurable later)
 - Added basic error types for failed requests. Since the API docs do not have the error message structure, I had to reverse engineer this a bit so it may need to change in the future.