### PR TITLE
Embeddings example and updated error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -107,7 +107,7 @@ func (mc *MistralClient) handleErrorResp(resp *http.Response) error {
 		return err
 	}
 	if err := json.Unmarshal([]byte(errResp.Message), &errMessage); err != nil {
-		return err
+		return fmt.Errorf("error code %s: %s", errResp.Code, errResp.Message)
 	}
 	return fmt.Errorf("error code %s: %s", errResp.Code, errMessage.Detail[0].Msg)
 }

--- a/examples/embeddings/main.go
+++ b/examples/embeddings/main.go
@@ -1,5 +1,25 @@
 package main
 
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/robertjkeck2/go-mistral"
+)
+
 func main() {
-	// TODO
+	client := mistral.NewMistralClient(os.Getenv("MISTRAL_API_KEY"))
+	resp, err := client.CreateEmbedding(
+		context.Background(),
+		&mistral.EmbeddingRequest{
+			Model: "mistral-embed",
+			Input: []string{"What is the best French cheese?"},
+		},
+	)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(resp.Data[0].Embedding)
 }


### PR DESCRIPTION
 - Embeddings basic example
 - It appears that the error messages are not super consistent, so I just return the error message if it is not an `ErrorMessage` object